### PR TITLE
srtr: Delete drift_rate before outputting uref

### DIFF
--- a/lib/upipe-srt/upipe_srt_receiver.c
+++ b/lib/upipe-srt/upipe_srt_receiver.c
@@ -609,6 +609,7 @@ static void upipe_srt_receiver_timer(struct upump *upump)
 
         uref_clock_set_cr_sys(uref, cr_sys + upipe_srt_receiver->latency);
         uref_clock_delete_date_prog(uref);
+        uref_clock_delete_rate(uref);
         upipe_srt_receiver_output(upipe, uref, NULL); // XXX: use timer upump ?
 
         static uint64_t old;


### PR DESCRIPTION
(cherry picked from commit d6ae88b610a5e2c131fe6bfc4a3f6ee10ad3d8c8)